### PR TITLE
Fixed obsolete double equality conjunction tests

### DIFF
--- a/algebra/algebra/print-out-equation.soar
+++ b/algebra/algebra/print-out-equation.soar
@@ -54,9 +54,9 @@ sp {algebra*apply*print-out-equation
 
 
 sp {algebra*apply*print-out-equation*other*print-op
-   (state <s> ^operator.name { <name> solve-problem }
+   (state <s> ^operator.name solve-problem
               ^top-state.io.output-link <out>)
 -->
-   (<out> ^text.next.value <name>)
+   (<out> ^text.next.value solve-problem)
 }
 

--- a/blocks-world-simple/blocks-world-simple/all/print-blocks.soar
+++ b/blocks-world-simple/blocks-world-simple/all/print-blocks.soar
@@ -10,7 +10,7 @@ sp {P10*apply*move-block*internal*done
 
 sp {P13*monitor*move-block*print-5stack
 :o-support
-   (state <s> ^print-move {true <p1>})
+   (state <s> ^print-move true)
    (<s> ^ontop <on1>
         ^ontop {<> <on1> <> <on3> <> <on4> <> <on5> <on2>}
         ^ontop {<> <on1> <> <on2> <> <on4> <> <on5> <on3>}
@@ -23,12 +23,12 @@ sp {P13*monitor*move-block*print-5stack
    (<on5> ^top-block.name <b5> ^bottom-block.name table)
    (<s> ^clear.name <b1>)
 -->
-   (<s> ^print-move <p1> -)
+   (<s> ^print-move true -)
    (write (crlf) <b5> <b4> <b3> <b2> <b1>)}
    
 sp {P13*monitor*move-block*print-4stack
 :o-support
-   (state <s> ^print-move {true <p1>})
+   (state <s> ^print-move true)
    (<s> ^ontop <on1>
         ^ontop {<> <on1> <> <on3> <> <on4> <on2>}
         ^ontop {<> <on1> <> <on2> <> <on4> <on3>}
@@ -39,12 +39,12 @@ sp {P13*monitor*move-block*print-4stack
    (<on4> ^top-block.name <b4> ^bottom-block.name table)
    (<s> ^clear.name <b1>)
 -->
-   (<s> ^print-move <p1> -)
+   (<s> ^print-move true -)
    (write (crlf) <b4> <b3> <b2> <b1>)}
    
 sp {P13*monitor*move-block*print-3stack
 :o-support
-   (state <s> ^print-move {true <p1>})
+   (state <s> ^print-move true)
    (<s> ^ontop <on1>
         ^ontop {<> <on1> <> <on3> <on2>}
         ^ontop {<> <on1> <> <on2> <on3>})
@@ -53,29 +53,29 @@ sp {P13*monitor*move-block*print-3stack
    (<on3> ^top-block.name <b3> ^bottom-block.name table)
    (<s> ^clear.name <b1>)
 -->
-   (<s> ^print-move <p1> -)
+   (<s> ^print-move true -)
    (write (crlf) <b3> <b2> <b1>)}
    
 sp {P13*monitor*move-block*print-2stack
 :o-support
-   (state <s> ^print-move {true <p1>})
+   (state <s> ^print-move true)
    (<s> ^ontop <on1>
         ^ontop {<> <on1> <on2>})
    (<on1> ^top-block.name <b1> ^bottom-block.name <b2>)
    (<on2> ^top-block.name <b2> ^bottom-block.name table)
    (<s> ^clear.name <b1>)
 -->
-   (<s> ^print-move <p1> -)
+   (<s> ^print-move true -)
    (write (crlf) <b2> <b1>)}
 
 sp {P13*monitor*move-block*print-1stack
 :o-support
-   (state <s> ^print-move {true <p1>})
+   (state <s> ^print-move true)
    (<s> ^ontop <on1>)
    (<on1> ^top-block.name <b1> ^bottom-block.name table)
    (<s> ^clear.name <b1>)
 -->
-   (<s> ^print-move <p1> -)
+   (<s> ^print-move true -)
    (write (crlf) <b1>)}
 
 sp {blocks-world*apply*initialize

--- a/mac-planning-9.4/mac-planning.soar
+++ b/mac-planning-9.4/mac-planning.soar
@@ -1,3 +1,3 @@
 pushd mac-planning
-source mac-planning_source.soar
+source mac-planning-9.4_source.soar
 popd


### PR DESCRIPTION
Fixed constant+var equality conjunctions in algebra and blocks-world-simple.
Fixed bad source reference in mac-planning-9.4.

Detailed review of updates supplied in attached new_conjunction_changelog.txt file, which includes mentions of non-conjunction-update source warnings or rule excisions encountered which were left as-is for now.

[new_conjunction_changelog.txt](https://github.com/SoarGroup/Agents/files/490930/new_conjunction_changelog.txt)
